### PR TITLE
Unregister model discriminators when disconnecting

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -64,6 +64,8 @@ Modulestore.prototype.detachConnection = function () {
         throw new Error('modulestore: no connection attached');
     }
 
+    models.cleanup();
+
     this.removeAllListeners(this.connection);
     delete this.connection;
 

--- a/lib/models/index.js
+++ b/lib/models/index.js
@@ -1,16 +1,16 @@
 'use strict';
 
-var mongoose = require('mongoose');
+var mongoose         = require('mongoose');
 
 // Register `Long' type
 require('mongoose-long')(mongoose);
 
-var ModuleSchema = require('./module');
-var CourseSchema = require('./course');
-var AboutSchema = require('./about');
-var ChapterSchema = require('./chapter');
+var ModuleSchema     = require('./module');
+var CourseSchema     = require('./course');
+var AboutSchema      = require('./about');
+var ChapterSchema    = require('./chapter');
 var SequentialSchema = require('./sequential');
-var ProblemSchema = require('./problem');
+var ProblemSchema    = require('./problem');
 
 // ## //
 
@@ -18,6 +18,7 @@ var Module, Course, About, Chapter, Sequential, Problem;
 
 var setup = function (connection) {
     Module = connection.model('Module', ModuleSchema);
+
     Course = Module.discriminator('course', CourseSchema);
     About = Module.discriminator('about', AboutSchema);
     Chapter = Module.discriminator('chapter', ChapterSchema);
@@ -25,9 +26,25 @@ var setup = function (connection) {
     Problem = Module.discriminator('problem', ProblemSchema);
 };
 
+var cleanup = function () {
+    // This removes the discriminatorKey from the schemas.
+    // We’re doing this to make sure that the schema/models
+    // are re-usable.
+    // Model.discriminator will call Schema.add() with the
+    // configured discriminatorKey. Calling Model.discriminator()
+    // when the discriminatorKey is already defined will fail.
+
+    CourseSchema.remove(CourseSchema.options.discriminatorKey);
+    AboutSchema.remove(AboutSchema.options.discriminatorKey);
+    ChapterSchema.remove(ChapterSchema.options.discriminatorKey);
+    SequentialSchema.remove(SequentialSchema.options.discriminatorKey);
+    ProblemSchema.remove(ProblemSchema.options.discriminatorKey);
+};
+
 // ## //
 
 exports.setup = setup;
+exports.cleanup = cleanup;
 
 exports.__defineGetter__('Module',      function () { return Module; });
 exports.__defineGetter__('Course',      function () { return Course; });


### PR DESCRIPTION
This allows us to reuse models accross multiple connections.